### PR TITLE
fix bug when person not extracted in transfer money form & floats for payment amounts

### DIFF
--- a/actions.py
+++ b/actions.py
@@ -380,8 +380,7 @@ class TransferForm(CustomFormAction):
 
         return {
             "PERSON": [
-                self.from_entity(entity="PERSON"),
-                self.from_text(intent=["inform", None, "transfer_money"]),
+                self.from_entity(entity="PERSON")
             ],
             "amount-of-money": [
                 self.from_entity(entity="amount-of-money"),

--- a/config.yml
+++ b/config.yml
@@ -24,6 +24,7 @@ pipeline:
 
 policies:
 - name: FallbackPolicy
+  nlu_threshold: 0.75
 - name: AugmentedMemoizationPolicy
 - name: FormPolicy
 - name: MappingPolicy

--- a/data/stories.md
+++ b/data/stories.md
@@ -1,8 +1,6 @@
 ## greet/bye path
 * greet
   - utter_greet
-* deny
-  - utter_goodbye
 
 ## say goodbye
 * goodbye


### PR DESCRIPTION
closes https://github.com/RasaHQ/financial-demo/issues/9
closes https://github.com/RasaHQ/financial-demo/issues/8
When `PERSON` could not be extracted in `transfer_money` flow, and the intent was predicted as `affirm`, it would trip the circuit breaker due to repeatedly predicting `action_execution_rejected`. Fixing the slot mapping and fallback threshold fixes that. 

Also, allow floats for payment amounts in credit card payment form