### PR TITLE
replace setenv commands

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -67,7 +67,7 @@ jobs:
           contains(  steps.files.outputs.all, 'data/' ) 
           || contains(  steps.files.outputs.all, 'config.yml' ) 
           || contains(  steps.files.outputs.all, 'domain.yml' )
-      run: echo "::set-env name=RUN_TRAINING::true"
+      run: echo "RUN_TRAINING=true" >> $GITHUB_ENV
     - name: Set up Python 3.7
       if: env.RUN_TRAINING == 'true'
       uses: actions/setup-python@v1
@@ -131,7 +131,7 @@ jobs:
       if: |
         contains(  steps.files.outputs.all, 'actions/' ) 
         || contains(  steps.files.outputs.all, 'Dockerfile' )
-      run: echo "::set-env name=ACTIONS_CHANGED::true"
+      run: echo "ACTIONS_CHANGED=true" >> $GITHUB_ENV
 
     - name: Login to DockerHub Registry 🔢
       run: echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u ${{ env.DOCKERHUB_USERNAME }} --password-stdin || true


### PR DESCRIPTION
Replace deprecated set-env commands in CI because of https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/