### PR TITLE
Explain where to find the bot for Rasa 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Notes on Rasa `1.x / 2.0`
 
-1. You are looking the bot for  **Rasa 1.x**
+1. The master branch of this repo is compatible with Rasa Open Source **version 1.x**
 2. The bot for **Rasa 2.0** can be found in the [rasa-2-0 branch](https://github.com/RasaHQ/financial-demo/tree/rasa-2-0).
 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Notes on Rasa `1.x / 2.0`
+
+1. You are looking the bot for  **Rasa 1.x**
+2. The bot for **Rasa 2.0** can be found in the [rasa-2-0 branch](https://github.com/RasaHQ/financial-demo/tree/rasa-2-0).
+
+
 
 # Financial Services Example Bot
 


### PR DESCRIPTION
This is a temporary note in the README of the master branch, to explain where the bot for Rasa 2.0 can be found.

Once the Udemy workshop has been updated to Rasa 2.0, the `rasa-2-0` branch can be merged into master, and this note can be removed.