### PR TITLE
Persistent volume cleanup

### DIFF
--- a/.github/trigger.txt
+++ b/.github/trigger.txt
@@ -1,2 +1,2 @@
 # A dummy file to trigger the workflow without making any actual change.
-# Just change something arbitrary in this text, like a space.
+# Just change something arbitrary in this text, like a space .

--- a/.github/trigger.txt
+++ b/.github/trigger.txt
@@ -1,2 +1,2 @@
 # A dummy file to trigger the workflow without making any actual change.
-# Just change something arbitrary in this text, like a space .
+# Just change something arbitrary in this text, like a space.

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -90,9 +90,13 @@ jobs:
         id: rasa_model
         run: |
           github_event_name=$(echo ${GITHUB_EVENT_NAME})
-          echo $github_event_name
+          echo "github_event_name: $github_event_name"
+          
+          aws_s3_rasa_model_exists=$( make aws-s3-rasa-model-exists )
+          echo "aws_s3_rasa_model_exists: $aws_s3_rasa_model_exists"
           
           if [[ $github_event_name == 'workflow_dispatch' ]] || \
+             [[ $aws_s3_rasa_model_exists == 'false' ]] || \
              [[ "${{ steps.files.outputs.all }}" == *"data/"* ]] || \
              [[ "${{ steps.files.outputs.all }}" == *"config.yml"* ]] || \
              [[ "${{ steps.files.outputs.all }}" == *"domain.yml"* ]] || \

--- a/.github/workflows/cleanup-branch.yml
+++ b/.github/workflows/cleanup-branch.yml
@@ -63,8 +63,13 @@ jobs:
           echo "Delete rasa model of branch ${{ github.event.ref }}"
           make aws-s3-delete-rasa-model GIT_BRANCH_NAME=${{ github.event.ref }}
 
-      - name: Cleanup EKS
+      - name: Cleanup EKS & all Persistent Volume Claims / Persistent Volumes
         run: |
-          echo "Delete test cluster of branch ${{ github.event.ref }}"
+          echo "Delete test cluster of branch ${{ github.event.ref }} and PVCs"
+          make install-kubectl
+          make install-helm
           make install-eksctl
+          make aws-eks-cluster-update-kubeconfig GIT_BRANCH_NAME=${{ github.event.ref }}
+          make rasa-enterprise-uninstall
+          make rasa-enterprise-delete-pvc-all
           make aws-eks-cluster-delete GIT_BRANCH_NAME=${{ github.event.ref }}

--- a/.github/workflows/cleanup-nightly.yml
+++ b/.github/workflows/cleanup-nightly.yml
@@ -54,5 +54,7 @@ jobs:
       - name: Cleanup EKS
         run: |
           echo "Delete all test clusters"
+          make install-kubectl
+          make install-helm
           make install-eksctl
           make aws-eks-cluster-delete-all-test-clusters

--- a/Makefile
+++ b/Makefile
@@ -539,9 +539,11 @@ aws-eks-cluster-get-certificateAuthority:
 aws-eks-cluster-update-kubeconfig:
 	@echo Updating kubeconfig for AWS EKS cluster with name: $(AWS_EKS_CLUSTER_NAME)
 	@echo $(NEWLINE)
+	chmod 600 ~/.kube/config
 	aws eks update-kubeconfig \
 		--region $(AWS_REGION) \
 		--name $(AWS_EKS_CLUSTER_NAME)
+	
 
 aws-eks-namespace-create:
 	kubectl create namespace $(AWS_EKS_NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -
@@ -653,16 +655,40 @@ rasa-enterprise-install:
 		--timeout=20m \
 		--all \
 		deployment
+		
+	@echo $(NEWLINE)
+	@echo Restarting action server pod
+	@kubectl --namespace $(AWS_EKS_NAMESPACE) rollout restart deployment $(AWS_EKS_RELEASE_NAME)-app
+	
+	@echo $(NEWLINE)
+	@echo Waiting again until all deployments are AVAILABLE
+	@kubectl --namespace $(AWS_EKS_NAMESPACE) \
+		wait \
+		--for=condition=available \
+		--timeout=5m \
+		--all \
+		deployment
 
 	@echo $(NEWLINE)
 	@echo Waiting for external IP assignment
 	@./scripts/wait_for_external_ip.sh $(AWS_EKS_NAMESPACE) $(AWS_EKS_RELEASE_NAME)
 
 rasa-enterprise-uninstall:
-	@echo Uninstalling Rasa Enterprise release $(AWS_EKS_RELEASE_NAME).
-	@echo $(NEWLINE)
-	@helm --namespace $(AWS_EKS_NAMESPACE) \
-		uninstall $(AWS_EKS_RELEASE_NAME)
+	@$(eval RELEASE_EXISTS := $(shell make rasa-enterprise-release-exists AWS_EKS_NAMESPACE=$(AWS_EKS_NAMESPACE) AWS_EKS_RELEASE_NAME=$(AWS_EKS_RELEASE_NAME) ))
+
+	@if [[ ${RELEASE_EXISTS} == "false" ]]; then \
+		echo "$(AWS_EKS_NAMESPACE):$(AWS_EKS_RELEASE_NAME) does not exist. Nothing to delete."; \
+	else \
+		echo "Uninstalling Rasa Enterprise release $(AWS_EKS_NAMESPACE):$(AWS_EKS_RELEASE_NAME)"; \
+		helm --namespace $(AWS_EKS_NAMESPACE) uninstall $(AWS_EKS_RELEASE_NAME); \
+	fi
+
+rasa-enterprise-release-exists:
+	@helm list --namespace $(AWS_EKS_NAMESPACE) --output json | jp "contains([].name, '$(AWS_EKS_RELEASE_NAME)')"
+
+rasa-enterprise-delete-pvc-all:
+	@echo Deleting all Persistent Volume Claims in $(AWS_EKS_NAMESPACE)
+	@kubectl --namespace $(AWS_EKS_NAMESPACE) delete pvc --all --wait=true
 
 rasa-enterprise-check-health:
 	@$(eval URL := $(shell make rasa-enterprise-get-base-url)/api/health)
@@ -683,6 +709,57 @@ rasa-enterprise-get-pods:
 	@kubectl --namespace $(AWS_EKS_NAMESPACE) \
 		get pods
 
+rasa-enterprise-get-pod-for-postgresql:
+	@kubectl --namespace $(AWS_EKS_NAMESPACE) \
+		get endpoints $(AWS_EKS_RELEASE_NAME)-rasa-x-postgresql \
+		--output jsonpath='{.subsets[*].addresses[0].targetRef.name}'
+		
+rasa-enterprise-get-pod-for-rabbit:
+	@kubectl --namespace $(AWS_EKS_NAMESPACE) \
+		get endpoints $(AWS_EKS_RELEASE_NAME)-rasa-x-rabbit \
+		--output jsonpath='{.subsets[*].addresses[0].targetRef.name}'
+		
+rasa-enterprise-get-pod-for-app:
+	@kubectl --namespace $(AWS_EKS_NAMESPACE) \
+		get endpoints $(AWS_EKS_RELEASE_NAME)-rasa-x-app \
+		--output jsonpath='{.subsets[*].addresses[0].targetRef.name}'
+		
+rasa-enterprise-get-pod-for-db-migration-service-headless:
+	@kubectl --namespace $(AWS_EKS_NAMESPACE) \
+		get endpoints $(AWS_EKS_RELEASE_NAME)-rasa-x-db-migration-service-headless \
+		--output jsonpath='{.subsets[*].addresses[0].targetRef.name}'
+		
+rasa-enterprise-get-pod-for-duckling:
+	@kubectl --namespace $(AWS_EKS_NAMESPACE) \
+		get endpoints $(AWS_EKS_RELEASE_NAME)-rasa-x-duckling \
+		--output jsonpath='{.subsets[*].addresses[0].targetRef.name}'
+		
+rasa-enterprise-get-pod-for-nginx:
+	@kubectl --namespace $(AWS_EKS_NAMESPACE) \
+		get endpoints $(AWS_EKS_RELEASE_NAME)-rasa-x-nginx \
+		--output jsonpath='{.subsets[*].addresses[0].targetRef.name}'
+		
+rasa-enterprise-get-pod-for-rasa-production:
+	@kubectl --namespace $(AWS_EKS_NAMESPACE) \
+		get endpoints $(AWS_EKS_RELEASE_NAME)-rasa-x-rasa-production \
+		--output jsonpath='{.subsets[*].addresses[0].targetRef.name}'
+		
+rasa-enterprise-get-pod-for-rasa-worker:
+	@kubectl --namespace $(AWS_EKS_NAMESPACE) \
+		get endpoints $(AWS_EKS_RELEASE_NAME)-rasa-x-rasa-worker \
+		--output jsonpath='{.subsets[*].addresses[0].targetRef.name}'
+		
+rasa-enterprise-get-pod-for-rasa-x:
+	@kubectl --namespace $(AWS_EKS_NAMESPACE) \
+		get endpoints $(AWS_EKS_RELEASE_NAME)-rasa-x-rasa-x \
+		--output jsonpath='{.subsets[*].addresses[0].targetRef.name}'
+		
+rasa-enterprise-get-pod-for-redis-master:
+	@kubectl --namespace $(AWS_EKS_NAMESPACE) \
+		get endpoints $(AWS_EKS_RELEASE_NAME)-rasa-x-redis-master \
+		--output jsonpath='{.subsets[*].addresses[0].targetRef.name}'
+		
+
 rasa-enterprise-get-secrets-postgresql:
 	@kubectl --namespace $(AWS_EKS_NAMESPACE) \
 		get secret $(AWS_EKS_RELEASE_NAME)-postgresql -o yaml | \
@@ -698,10 +775,23 @@ rasa-enterprise-get-secrets-rabbit:
 		get secret $(AWS_EKS_RELEASE_NAME)-rabbit -o yaml | \
 		awk -F ': ' '/password/{print $2}' | base64 -d
 
-
+rasa-enterprise-get-base-url:
+	@kubectl --namespace $(AWS_EKS_NAMESPACE) \
+		get service $(AWS_EKS_RELEASE_NAME)-rasa-x-nginx \
+		--output jsonpath='{.status.loadBalancer.ingress[0].hostname}' | \
+		awk '{v="http://"$$1":80"; print v}'
+		
 rasa-enterprise-get-login:
 	@./scripts/wait_for_external_ip.sh $(AWS_EKS_NAMESPACE) $(AWS_EKS_RELEASE_NAME) 1
 
+rasa-enterprise-admin-user-create:
+	@$(eval POD_RASA_X := $(shell make rasa-enterprise-get-pod-for-rasa-x))
+	@kubectl --namespace $(AWS_EKS_NAMESPACE) exec $(POD_RASA_X) -- python scripts/manage_users.py create $(RASAX_INITIALUSER_USERNAME) $(RASAX_INITIALUSER_PASSWORD) admin
+
+rasa-enterprise-admin-user-update:
+	@$(eval POD_RASA_X := $(shell make rasa-enterprise-get-pod-for-rasa-x))
+	@kubectl --namespace $(AWS_EKS_NAMESPACE) exec $(POD_RASA_X) -- python scripts/manage_users.py create --update $(RASAX_INITIALUSER_USERNAME) $(RASAX_INITIALUSER_PASSWORD) admin
+				
 rasa-enterprise-get-access-token:
 	@$(eval URL := $(shell make rasa-enterprise-get-base-url)/api/auth)
 	@curl --silent --request POST --url $(URL) \
@@ -775,12 +865,6 @@ rasa-enterprise-smoketest:
 	@$(eval URL := $(shell make rasa-enterprise-get-base-url))
 	export BASE_URL=$(URL); \
 	python ./scripts/smoketest.py
-
-rasa-enterprise-get-base-url:
-	@kubectl --namespace $(AWS_EKS_NAMESPACE) \
-		get service $(AWS_EKS_RELEASE_NAME)-rasa-x-nginx \
-		--output jsonpath='{.status.loadBalancer.ingress[0].hostname}' | \
-		awk '{v="http://"$$1":80"; print v}'
 
 rasa-enterprise-get-loadbalancer-hostname:
 	@kubectl --namespace $(AWS_EKS_NAMESPACE) \

--- a/Makefile
+++ b/Makefile
@@ -539,10 +539,10 @@ aws-eks-cluster-get-certificateAuthority:
 aws-eks-cluster-update-kubeconfig:
 	@echo Updating kubeconfig for AWS EKS cluster with name: $(AWS_EKS_CLUSTER_NAME)
 	@echo $(NEWLINE)
-	chmod 600 ~/.kube/config
 	aws eks update-kubeconfig \
 		--region $(AWS_REGION) \
 		--name $(AWS_EKS_CLUSTER_NAME)
+	chmod 600 ~/.kube/config
 	
 
 aws-eks-namespace-create:

--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@ FROM rasa/rasa-sdk:2.5.0
 # file: Makefile
 
 RASAX_TAG := 0.39.3
-RASAX_HELM_CHART_VERSION := latest
+RASAX_HELM_CHART_VERSION := 2.0.0
 ```
 
 
@@ -679,12 +679,14 @@ Build, run, test & push the action docker server image, with name:
 - `<ECR URI>/financial-demo:<current branch name>`
 
 ```bash
-# Verify that the correct rasa-sdk is selected in `Dockerfile`
-# ==> FROM rasa/rasa-sdk:....
-#
-# Then, build the image with:
+# check out the `main` branch.
+# -> the branch name is used as the image tag
+git checkout main
+
+# build the image
 make docker-build
 
+# test it
 make docker-run
 make docker-test
 make docker-stop
@@ -704,7 +706,13 @@ make aws-eks-cluster-update-kubeconfig AWS_EKS_CLUSTER_NAME=financial-demo-produ
 # check it
 make kubectl-config-current-context  AWS_EKS_CLUSTER_NAME=financial-demo-production
 
-# if you want to re-install from scratch, delete the namespace
+# check out the `main` branch.
+# -> The action server docker image with tag = current branch name will be installed
+git checkout main
+
+# if you want to re-install rasa enterprise completely from scratch:
+make rasa-enterprise-uninstall
+make rasa-enterprise-delete-pvc-all
 make aws-eks-namespace-delete
 
 # create namespace `my-namespace`
@@ -728,6 +736,9 @@ make rasa-enterprise-check-health
 ### Train, test & upload model to S3
 
 ```bash
+# check out the `main` branch.
+git checkout main
+
 # Train the model: `models/<current branch>.tar.gz`
 make rasa-train
 


### PR DESCRIPTION
When deleting test clusters, it is needed to first delete the persistent volume claims, else the persistent storage for postgresql, redis & rabbit will not be deleted. 

The persistent storage volumes are AWS EBS volumes.