### PR TITLE
fix: required versions of sqlalchemy and rasa-sdk

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: https://github.com/ambv/black
-    rev: stable
+-   repo: https://github.com/psf/black
+    rev: 23.3.0
     hooks:
     - id: black

--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ To install development dependencies:
 ```bash
 pip install -r requirements-dev.txt
 pre-commit install
-python -m spacy download en_core_web_md en
-python -m spacy link en_core_web_md en
+python -m spacy download en_core_web_md
 ```
 
-> With pre-commit installed, the `black` and `doctoc` hooks will run on every `git commit`.
-> If any changes are made by the hooks, you will need to re-add changed files and re-commit your changes.
+> With pre-commit installed, the `black` and `doctoc` hooks will run on every
+> `git commit`. If any changes are made by the hooks, you will need to re-add
+> changed files and re-commit your changes.
 
 ## Run the bot
 

--- a/actions/profile_db.py
+++ b/actions/profile_db.py
@@ -2,7 +2,7 @@ import os
 import sqlalchemy as sa
 from sqlalchemy import Column, Integer, String, DateTime, REAL
 from sqlalchemy.orm import Session, sessionmaker
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.engine.base import Engine
 from typing import Dict, Text, List, Union, Optional
 

--- a/actions/requirements-actions.txt
+++ b/actions/requirements-actions.txt
@@ -2,4 +2,4 @@ python-dateutil==2.8.1
 numpy~=1.19.2
 pytz~=2019.3
 ruamel.yaml
-sqlalchemy~=1.3.22
+sqlalchemy~=1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ rasa[spacy]==3.1.0
 
 # Sync with `Dockerfile`
 rasa-sdk~=3.1.1
+websockets~=10.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@
 rasa[spacy]==3.1.0
 
 # Sync with `Dockerfile`
-rasa-sdk==3.1.0
+rasa-sdk~=3.1.1


### PR DESCRIPTION
Use [compatible release syntax](https://peps.python.org/pep-0440/#compatible-release) to
declare `sqlalchemy` and `rasa-sdk` dependencies of `rasa[spacy] 3.1.0`